### PR TITLE
Fixed broken Grant Searle url

### DIFF
--- a/Arduino/libraries/Hi-Res Video Driver Source/readme.txt
+++ b/Arduino/libraries/Hi-Res Video Driver Source/readme.txt
@@ -15,7 +15,7 @@ The video processor code is written by Grant Searle, based on code by Daryl Rict
 
 Their pages are as follows:
 
-http://searle.hostei.com/grant/MonitorKeyboard/index.html
+http://searle.x10host.com/MonitorKeyboard/index.html
 http://sbc.rictor.org/vid3.html
 
 80x25 Terminal library by Dave Curran, based on code from the above. For more info see:


### PR DESCRIPTION
Grant Searle's website is no longer at http://searle.hostei.com/grant/MonitorKeyboard/index.html